### PR TITLE
Replaced test meta from +junit to +tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-http</name>
   <properties>
-    <eolang.version>0.29.0</eolang.version>
+    <eolang.version>0.29.4</eolang.version>
   </properties>
   <description>HTTP objects for EOLANG</description>
   <url>https://github.com/objectionary/eo-http</url>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["maven-compiler-plugin"],
+      "allowedVersions": "3.8.1"
+    }
   ]
 }

--- a/src/main/eo/org/eolang/http/http-request.eo
+++ b/src/main/eo/org/eolang/http/http-request.eo
@@ -1,5 +1,5 @@
-+package org.eolang.http
 +alias org.eolang.txt.sprintf
++package org.eolang.http
 
 [body] > http-request
   "GET" > method

--- a/src/test/eo/org/eolang/http/http-request-tests.eo
+++ b/src/test/eo/org/eolang/http/http-request-tests.eo
@@ -1,8 +1,7 @@
-+package org.eolang.http
-
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.http.http-request
-+junit
++tests
++package org.eolang.http
 
 [] > converts-to-string
   assert-that > @


### PR DESCRIPTION
Closes: #12
- Replaced test meta from +junit to +tests
- changed metas order
- updated EO version to 0.29.4

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `pom.xml` file and adds a package rule to the `renovate.json` file. It also adds aliases to the `http-request-tests.eo` file.

### Detailed summary
- Updates `eolang.version` in `pom.xml` from `0.29.0` to `0.29.4`
- Adds a package rule to `renovate.json` for the `maven-compiler-plugin` package
- Adds aliases to `http-request-tests.eo` for `org.eolang.hamcrest.assert-that` and `org.eolang.http.http-request`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->